### PR TITLE
Allow clearing workout goal time fields and add coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ https://goober-app.vercel.app
 
    ```
    git clone https://github.com/grubers-goobers/goober_app.git
-   cd goober-app
+   cd goober_app
    ```
 
 2. Run the setup command:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "prisma migrate deploy && next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "ts-node --project tsconfig.test.json tests/validateTimeInput.test.ts",
     "postinstall": "prisma generate && prisma migrate deploy",
     "devdb": "docker compose up -d && prisma migrate dev"
   },

--- a/prompts/workout/v0.0.2.txt
+++ b/prompts/workout/v0.0.2.txt
@@ -2,7 +2,7 @@ System Prompt for Single Workout Generation:
 
 You are a seasoned endurance coach with extensive expertise in running, cycling, swimming, and triathlon training. Your task is to generate a single, well-structured workout based on the user's input. The output will follow a structured format (validated by a Zod or Pydantic schema), so your focus is on the content and details of the workout.
 
-Please follow the users instructions carefully.  The user instructionser are the following:
+Please follow the users instructions carefully.  The user instructions are the following:
 
 {userPrompt}
 

--- a/tests/validateTimeInput.test.ts
+++ b/tests/validateTimeInput.test.ts
@@ -1,0 +1,50 @@
+import { strict as assert } from "assert";
+import { validateTimeInput } from "../utils/workout-validation";
+
+type TestFn = () => void;
+
+const results: { name: string; error: Error | null }[] = [];
+
+function test(name: string, fn: TestFn) {
+  try {
+    fn();
+    results.push({ name, error: null });
+  } catch (error) {
+    results.push({ name, error: error as Error });
+  }
+}
+
+test("allows clearing the field for any time unit", () => {
+  assert.equal(validateTimeInput("", "hours"), true);
+  assert.equal(validateTimeInput("", "minutes"), true);
+  assert.equal(validateTimeInput("", "seconds"), true);
+});
+
+test("accepts boundary values for each unit", () => {
+  assert.equal(validateTimeInput("0", "hours"), true);
+  assert.equal(validateTimeInput("99", "hours"), true);
+  assert.equal(validateTimeInput("59", "minutes"), true);
+  assert.equal(validateTimeInput("59", "seconds"), true);
+});
+
+test("rejects values outside the allowed range", () => {
+  assert.equal(validateTimeInput("-1", "hours"), false);
+  assert.equal(validateTimeInput("100", "hours"), false);
+  assert.equal(validateTimeInput("60", "minutes"), false);
+  assert.equal(validateTimeInput("60", "seconds"), false);
+});
+
+const failed = results.filter((result) => result.error);
+
+results.forEach((result) => {
+  if (result.error) {
+    console.error(`✖ ${result.name}`);
+    console.error(result.error.message);
+  } else {
+    console.log(`✔ ${result.name}`);
+  }
+});
+
+if (failed.length > 0) {
+  process.exitCode = 1;
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": false
+  }
+}

--- a/utils/workout-validation.ts
+++ b/utils/workout-validation.ts
@@ -30,6 +30,7 @@ export const validateTimeInput = (
   value: string,
   type: "hours" | "minutes" | "seconds"
 ): boolean => {
+  if (value === "") return true;
   const numValue = parseInt(value, 10);
   if (isNaN(numValue) || numValue < 0) return false;
   if (type === "hours" && numValue > 99) return false;


### PR DESCRIPTION
## Summary
- fix the workout generation prompt typo so it reads "instructions"
- allow goal time inputs to accept empty strings while keeping range limits
- align the README setup step with the actual repository name
- add a lightweight ts-node test harness that exercises validateTimeInput edge cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2f433a7e0832c87585667f68fb920